### PR TITLE
[FLINK-28198] Integrate tests with CassandraTestEnvironment which manages the cassandra cluster container, session, retrials and timeouts. Cleaning

### DIFF
--- a/flink-connector-cassandra/src/test/java/org/apache/flink/connector/cassandra/source/CassandraSourceITCase.java
+++ b/flink-connector-cassandra/src/test/java/org/apache/flink/connector/cassandra/source/CassandraSourceITCase.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.connector.cassandra.source;
 
+import org.apache.flink.connector.cassandra.CassandraTestEnvironment;
 import org.apache.flink.connector.cassandra.source.enumerator.CassandraEnumeratorState;
 import org.apache.flink.connector.cassandra.source.split.CassandraSplit;
 import org.apache.flink.connector.cassandra.source.split.SplitsGenerator;


### PR DESCRIPTION
Do as the new source does for testing. Should cope with CI server load as there was no flaky tests on the Cassandra source since merged contrary to old connector/sink tests.

R: @MartijnVisser 
CC: @zentol 