### PR TITLE
[FLINK-31749] Disable cassandra driver metrics as they are not integrated with Flink metrics

### DIFF
--- a/flink-connector-cassandra/src/main/java/org/apache/flink/streaming/connectors/cassandra/ClusterBuilder.java
+++ b/flink-connector-cassandra/src/main/java/org/apache/flink/streaming/connectors/cassandra/ClusterBuilder.java
@@ -24,12 +24,13 @@ import java.io.Serializable;
 
 /**
  * This class is used to configure a {@link com.datastax.driver.core.Cluster} after deployment. The
- * cluster represents the connection that will be established to Cassandra.
+ * cluster represents the connection that will be established to Cassandra. Cassandra driver metrics
+ * are not integrated with Flink metrics, so they are disabled.
  */
 public abstract class ClusterBuilder implements Serializable {
 
     public Cluster getCluster() {
-        return buildCluster(Cluster.builder());
+        return buildCluster(Cluster.builder().withoutMetrics());
     }
 
     /**

--- a/flink-connector-cassandra/src/test/java/org/apache/flink/connector/cassandra/CassandraTestEnvironment.java
+++ b/flink-connector-cassandra/src/test/java/org/apache/flink/connector/cassandra/CassandraTestEnvironment.java
@@ -173,8 +173,6 @@ public class CassandraTestEnvironment implements TestResource {
                                         // default timeout x3 and higher than
                                         // request_timeout_in_ms at the cluster level
                                         .setReadTimeoutMillis(READ_TIMEOUT_MILLIS))
-                        .withoutJMXReporting()
-                        .withoutMetrics()
                         .build();
             }
         };

--- a/flink-connector-cassandra/src/test/java/org/apache/flink/streaming/connectors/cassandra/CassandraSinkBaseTest.java
+++ b/flink-connector-cassandra/src/test/java/org/apache/flink/streaming/connectors/cassandra/CassandraSinkBaseTest.java
@@ -62,10 +62,7 @@ class CassandraSinkBaseTest {
                         new ClusterBuilder() {
                             @Override
                             protected Cluster buildCluster(Cluster.Builder builder) {
-                                return builder.addContactPoint("127.0.0.1")
-                                        .withoutJMXReporting()
-                                        .withoutMetrics()
-                                        .build();
+                                return builder.addContactPoint("127.0.0.1").build();
                             }
                         },
                         CassandraSinkBaseConfig.newBuilder().build(),


### PR DESCRIPTION
R: @RyanSkraba 
CC: @zentol @dannycranmer 

