### PR TITLE
[hotfix] CQL_PROHIBITED_CLAUSES_REGEXP to match the "ORDER BY" keyword instead of just "ORDER"

### DIFF
--- a/flink-connector-cassandra/src/main/java/org/apache/flink/connector/cassandra/source/CassandraSource.java
+++ b/flink-connector-cassandra/src/main/java/org/apache/flink/connector/cassandra/source/CassandraSource.java
@@ -90,7 +90,7 @@ public class CassandraSource<OUT>
         implements Source<OUT, CassandraSplit, CassandraEnumeratorState>, ResultTypeQueryable<OUT> {
 
     public static final Pattern CQL_PROHIBITED_CLAUSES_REGEXP =
-            Pattern.compile("(?i).*(AVG|COUNT|MIN|MAX|SUM|ORDER|GROUP BY).*");
+            Pattern.compile("(?i).*(AVG|COUNT|MIN|MAX|SUM|ORDER BY|GROUP BY).*");
     public static final Pattern SELECT_REGEXP =
             Pattern.compile("(?i)select .+ from (\\w+)\\.(\\w+).*;$");
 


### PR DESCRIPTION
I encountered an issue where the CQL_PROHIBITED_CLAUSES_REGEXP would match such a request :
```
SELECT * from trade.orderbyid;
```
The pattern would match because my table is called `orderbyid` but it does not include a prohibited SQL clause (`ORDER BY` in this case).
A simple fix would be to match on the `ORDER BY` keyword instead of just `ORDER` which seems more appropriate to me.