### PR TITLE
[FLINK-36595][docs] Explicitly set connector compatibility as string

### DIFF
--- a/docs/data/cassandra.yml
+++ b/docs/data/cassandra.yml
@@ -1,0 +1,22 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+version: 3.2.0
+flink_compatibility: ["1.18", "1.19"]
+variants:
+  - maven: flink-connector-cassandra_2.12


### PR DESCRIPTION
Explicitly set connector compatibility as string to prevent version comparison mismatch

### Purpose of the change

* Add missing docs data file
* Add supported Flink versions for connector 3.2.0
* Set version as string to prevent version comparison mismatch. Issue has happened for other connectors too : https://github.com/apache/flink-connector-kafka/pull/132

### Significant changes

No significant change