### PR TITLE
[FLINK-38485] Fix/Improve tests

### DIFF
--- a/flink-connector-cassandra/pom.xml
+++ b/flink-connector-cassandra/pom.xml
@@ -44,7 +44,9 @@ under the License.
 		<junit5.version>5.8.1</junit5.version>
 		<assertj.version>3.23.1</assertj.version>
 		<archunit.version>1.0.0</archunit.version>
-		<testcontainers.version>1.18.3</testcontainers.version>
+		<!-- For dependency convergence we exclude testContainers commons-compress transitive dependency and keep only flink's.
+		Don't downgrade testcontainers otherwise the wrong commons-compress transitive dependency will lead to NoClassDefFound-->
+		<testcontainers.version>1.20.2</testcontainers.version>
 		<mockito.version>3.4.6</mockito.version>
 		<byte-buddy.version>1.12.10</byte-buddy.version>
 		<findbugs.version>1.3.9</findbugs.version>

--- a/flink-connector-cassandra/src/test/java/org/apache/flink/connector/cassandra/table/CassandraDynamicTableSourceITCase.java
+++ b/flink-connector-cassandra/src/test/java/org/apache/flink/connector/cassandra/table/CassandraDynamicTableSourceITCase.java
@@ -26,9 +26,10 @@ import org.apache.flink.test.junit5.MiniClusterExtension;
 import org.apache.flink.types.Row;
 import org.apache.flink.util.CloseableIterator;
 
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.math.BigDecimal;
@@ -43,12 +44,13 @@ import static org.assertj.core.api.Assertions.assertThat;
  * complex scenarios, edge cases, and error conditions.
  */
 @ExtendWith(MiniClusterExtension.class)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class CassandraDynamicTableSourceITCase {
 
     private CassandraTestEnvironment cassandraTestEnvironment;
     private StreamTableEnvironment tableEnv;
 
-    @BeforeEach
+    @BeforeAll
     void setUp() throws Exception {
         cassandraTestEnvironment = new CassandraTestEnvironment(false);
         cassandraTestEnvironment.startUp();
@@ -60,11 +62,9 @@ class CassandraDynamicTableSourceITCase {
         insertAllTestData();
     }
 
-    @AfterEach
+    @AfterAll
     void tearDown() throws Exception {
-        if (cassandraTestEnvironment != null) {
-            cassandraTestEnvironment.tearDown();
-        }
+        cassandraTestEnvironment.tearDown();
     }
 
     private void createAllTestTables() {
@@ -1526,7 +1526,7 @@ class CassandraDynamicTableSourceITCase {
     @Test
     void testFieldProjectionAndQueryOptimization() throws Exception {
         String createFlinkTable =
-                "CREATE TABLE flink_primitives ("
+                "CREATE TABLE flink_projections ("
                         + "  id INT,"
                         + "  name STRING,"
                         + "  age INT,"
@@ -1549,7 +1549,7 @@ class CassandraDynamicTableSourceITCase {
                         + ")";
 
         tableEnv.executeSql(createFlinkTable);
-        Table result = tableEnv.sqlQuery("SELECT name, age FROM flink_primitives");
+        Table result = tableEnv.sqlQuery("SELECT name, age FROM flink_projections");
 
         List<Row> actualRows = collectResults(result, 2);
 


### PR DESCRIPTION
**Fix NoClassDefFound on org/apache/commons/codec/Charsets:** 
- What happened previously is that testContainers had a commons-compress transitive dep so it was compiled with this dep. But for dependency convergeance we exclude testContainers commons-compress transitive dep to have only flink's transitive dep on the classPath. The problem is that flink's  commons-compress transitive dep is newer than the one used for compilation of  testContainers and it removed Charsets class. Hence the noClassDefFound at runtime.
 => Upgrade testContainers to v1.20.2 which is compiled with a commons-compress version closer to the one flink uses and keep commons-compress transitive dep exclusion to favor flink's.

**Greatly improve test run time:** 
- Make setup and teardown (test environment start/stop, tables creation, test data insertion) global for the whole test case instead of once per test to avoid too long test run.

R: @Poorvankbhatia 
